### PR TITLE
Allow options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,16 @@ Few helper traits for quicker API  development in Symfony
 public function create(Request $request)
 	{
 	$entity = new Entity();
-	$this->handleJSONForm($request, $entity, EntityType::class);
+	$this->handleJSONForm($request, $entity, EntityType::class, $options = [], $clearMissingFields = true);
 	// persist and flush $entity
 ```
 
 ```php
 public function edit(Request $request,Entity $entity)
 	{
-	$this->handleJSONForm($request, $entity, EntityType::class);
+	$this->handleJSONForm($request, $entity, EntityType::class, $options = [], $clearMissingFields = true);
 	// flush entity
 ```
-
 ### `handleForm` 
 - controller helper method for traditional form data in `GET` or `POST`
 - I advice using traditional form data only when JSON is out of place (i.e. `GET` params)
@@ -31,7 +30,7 @@ public function example(Request $request)
 	$domain = new Domain();
 	if ($request->query->count() > 0)
 		{
-		$this->handleForm($request, $params, DomainType::class);
+		$this->handleForm($request, $params, DomainType::class, $options = [], $clearMissingFields = true);
 		}
 	
 	// do something with $domain

--- a/src/FormTrait.php
+++ b/src/FormTrait.php
@@ -22,11 +22,12 @@ trait FormTrait
 	 * @param Request $request
 	 * @param mixed $domain
 	 * @param string $formType
+     * @param array $options
 	 * @return Form
 	 */
-	protected function handleForm(Request $request, $domain, $formType)
+	protected function handleForm(Request $request, $domain, $formType, $options = [])
 		{
-		$form = $this->createForm($formType,$domain);
+		$form = $this->createForm($formType,$domain, $options);
 		$form->handleRequest($request);
 		$this->handleFormErrors($form);
 
@@ -39,15 +40,16 @@ trait FormTrait
 	 * @param Request $request Request with JSON posted data
 	 * @param object $domain
 	 * @param string $formType
+     * @param array $options
 	 * @param boolean $clearMissingFields set to TRUE when you want to validate the whole form (i.e. in POST or PUT) or to FALSE when form contains partial data (i.e. in PATCH)
 	 * @return Form
 	 * @throws BadJSONRequestException
 	 */
-	protected function handleJSONForm(Request $request, $domain, $formType, $clearMissingFields = true)
+	protected function handleJSONForm(Request $request, $domain, $formType, $options = [], $clearMissingFields = true)
 		{
 		$data = $this->getJsonContent($request);
 
-		$form = $this->createForm($formType,$domain);
+		$form = $this->createForm($formType,$domain, $options);
 		$form->submit($data,$clearMissingFields);
 		$this->handleFormErrors($form);
 


### PR DESCRIPTION
Allow usage of options in `handleJSONForm` and `handleForm` methods e.g.
```
$this->handleJSONForm($request, $entity, EntityType::class, ['validation_groups' => ['some_validation_group']]);
```